### PR TITLE
Minor improvements and cleanup for release 1.0.8

### DIFF
--- a/menus/phpunit.cson
+++ b/menus/phpunit.cson
@@ -1,16 +1,17 @@
 # See https://atom.io/docs/latest/creating-a-package#menus for more details
-'context-menu':
-  '.overlayer':
-      'Run PHPUnit Test': 'phpunit:test'
-
 'menu': [
-  {
-    'label': 'Packages'
-    'submenu': [
-      'label': 'phpunit'
-      'submenu': [
-        { 'label': 'Run PHPUnit Test', 'command': 'phpunit:test' }
-      ]
-    ]
-  }
+    {
+        'label': 'Packages'
+        'submenu': [
+            'label': 'phpunit'
+            'submenu': [
+                { 'label': 'Run PHPUnit Test', 'command': 'phpunit:test' }
+            ]
+        ]
+    }
 ]
+
+'context-menu':
+    '.overlayer': [
+            { 'label': 'Run PHPUnit Test', 'command': 'phpunit:test' }
+    ]

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "name": "phpunit",
   "main": "./lib/phpunit",
-  "version": "1.0.6",
+  "version": "1.0.8.",
   "private": false,
   "description": "A simple PHPUnit test runner.",
   "repository": "https://github.com/alairock/phpunit-atom",
   "license": "MIT",
   "engines": {
-    "atom": ">0.50.0"
+      "atom": ">0.50.0"
   },
-  "dependencies": {}
+  "dependencies": {
+      "fs-plus": "2.x",
+      "temp": "~0.6.0"
+  }
 }

--- a/spec/phpunit-spec.coffee
+++ b/spec/phpunit-spec.coffee
@@ -1,23 +1,61 @@
 {WorkspaceView} = require 'atom'
-Phpunit = require '../lib/phpunit'
+path = require 'path'
+fs = require 'fs-plus'
+temp = require 'temp'
 
-describe "Phpunit", ->
-  [activationPromise] = []
+describe "PHPUnit", ->
 
-  beforeEach ->
-    atom.workspaceView = new WorkspaceView
-    activationPromise = atom.packages.activatePackage('phpunit')
+    beforeEach ->
+        atom.workspaceView = new WorkspaceView
+        atom.workspace = atom.workspaceView.model
+        atom.config.set("phpunit.execPath", '/usr/local/bin/phpunit')
 
-  describe "when the phpunit:toggle event is triggered", ->
-    it "attaches and then detaches the view", ->
-      expect(atom.workspaceView.find('.phpunit-container')).not.toExist()
+        waitsForPromise ->
+            atom.packages.activatePackage('phpunit')
 
-      # This is an activation event, triggering it will cause the package to be
-      # activated.
-      atom.workspaceView.trigger 'phpunit:test'
+    describe "when the phpunit:test event is triggered", ->
+        it "attaches and then detaches the view", ->
+            expect(atom.workspaceView.find('.phpunit-container')).not.toExist
+            atom.workspaceView.trigger 'phpunit:test'
 
-      waitsForPromise ->
-        activationPromise
+            runs ->
+                expect(atom.workspaceView.find('.phpunit-container')).toExist
 
-      runs ->
-        expect(atom.workspaceView.find('.phpunit-container')).toExist()
+    describe "when the buffer is saved", ->
+        [editor, buffer] = []
+
+        beforeEach ->
+            directory = temp.mkdirSync()
+            atom.project.setPaths(directory)
+            filePath = path.join(directory, 'phpunit-atom.txt')
+            fs.writeFileSync(filePath, 'phpunit-spec')
+
+            waitsForPromise ->
+                atom.workspace.open(filePath).then (o) -> editor = o
+
+            runs ->
+                buffer = editor.getBuffer()
+
+        describe "when the RunOnSave option is enabled", ->
+
+            beforeEach ->
+                atom.config.set("phpunit.runOnSave", true)
+
+            it "attaches and then detaches the view", ->
+                expect(atom.workspaceView.find('.phpunit-container')).not.toExist
+                editor.save()
+
+                runs ->
+                    expect(atom.workspaceView.find('.phpunit-container')).toExist
+
+        describe "when the RunOnSave option is disabled", ->
+
+            beforeEach ->
+                atom.config.set("phpunit.runOnSave", false)
+
+            it "does nothing", ->
+                expect(atom.workspaceView.find('.phpunit-container')).not.toExist
+                buffer.save()
+
+                runs ->
+                    expect(atom.workspaceView.find('.phpunit-container')).not.toExist


### PR DESCRIPTION
- Rename option ExecuteOnSave to RunOnSave
- Update of settings labels
- Run on Save only run when a PHP file is saved
- Update of Test Spec
- Clean up of unused code
- Fix deprecated syntax of Context Menu

Code is ready for releasing a version 1.0.8 of the Atom package
