### PR TITLE
Phpunit on project path

### DIFF
--- a/lib/phpunit.coffee
+++ b/lib/phpunit.coffee
@@ -111,7 +111,7 @@ module.exports =
         exec = atom.config.get "phpunit.execPath"
         options =
           cwd: atom.project.getPaths()[0]
-        spawn exec, params
+        spawn exec, params, options
 
     killProcess: ->
         if @phpunit.pid

--- a/lib/phpunit.coffee
+++ b/lib/phpunit.coffee
@@ -109,6 +109,8 @@ module.exports =
         @phpUnitView.buttonKill.enable()
         spawn = require('child_process').spawn
         exec = atom.config.get "phpunit.execPath"
+        options =
+          cwd: atom.project.getPaths()[0]
         spawn exec, params
 
     killProcess: ->


### PR DESCRIPTION
When executing All Tests, `phpunit` was executed from a path different from the project's path, so that the reference between files (using `require`) gave errors.