### PR TITLE
Clear console before running tests

### DIFF
--- a/lib/phpunit.coffee
+++ b/lib/phpunit.coffee
@@ -98,6 +98,7 @@ module.exports =
 
 
     initView: ->
+        @phpUnitView.clear()
         atom.workspace.addBottomPanel({ item: @phpUnitView })
         @phpUnitView.output.on 'click', 'a', ->
             [uri, line] = "#{$(this).text()}".split ':'


### PR DESCRIPTION
I've cleared the output at `initView`. The effect is that the console is reset with every run of the tests.