### PR TITLE
Added command for hiding the phpunit window.

### DIFF
--- a/lib/phpunit.coffee
+++ b/lib/phpunit.coffee
@@ -44,6 +44,7 @@ module.exports =
         atom.commands.add 'atom-workspace', 'phpunit:current', => @runEditor atom.workspace.getActiveTextEditor()
         atom.commands.add 'atom-workspace', 'phpunit:workspace', => @runWorkspace()
         atom.commands.add 'atom-workspace', 'phpunit:kill', => @killProcess()
+        atom.commands.add 'atom-workspace', 'phpunit:hide', => @hideView()
         atom.workspace.observeTextEditors (editor) =>
             editor.getBuffer()?.onDidSave => @runOnSave editor
 
@@ -118,3 +119,6 @@ module.exports =
         if @phpunit.pid
           @phpUnitView.append 'Killing current PHPUnit execution...<br>'
           @phpunit.kill 'SIGHUP'
+
+    hideView: ->
+        @phpUnitView.close()

--- a/lib/phpunit.coffee
+++ b/lib/phpunit.coffee
@@ -81,7 +81,7 @@ module.exports =
       runnable ||= regexName.test(editor.getTitle())
 
     executeTests: (options) ->
-        @initView()
+        # @initView()
         @execPHPUnit options
         # @phpunit = @execPHPUnit options
         #
@@ -145,8 +145,8 @@ module.exports =
         @phpunit.on 'close', (code, signal) =>
             if signal then log = "Process killed with signal #{signal}"
             else log = 'Complete.'
-            @phpUnitView.append "<br>#{log}<br><hr>", false
-            @phpUnitView.buttonKill.disable()
+            # @phpUnitView.append "<br>#{log}<br><hr>", false
+            # @phpUnitView.buttonKill.disable()
             if @textEditor?
                 @textEditor.insertText(log)
 

--- a/lib/phpunit.coffee
+++ b/lib/phpunit.coffee
@@ -115,11 +115,13 @@ module.exports =
             line = 0 unless line
             atom.workspace.open uri, {initialLine: line}
 
-    textEditorDestroyed: ()-> @textEdtior = null
+    textEditorDestroyed: ()->
+        console.log('phpunit textEditor destroyed.')
+        @textEditor = null
 
     gotTextEditor: (textEdit, params)->
         @textEditor = textEdit
-        @textEditor.onDidDestroy(@textEditorDestroyed)
+        @textEditor.onDidDestroy( => @textEditorDestroyed() )
         options =
           cwd: atom.project.getPaths()[0]
         spawn = require('child_process').spawn
@@ -156,14 +158,15 @@ module.exports =
         # spawn = require('child_process').spawn
         # exec = atom.config.get "phpunit.execPath"
         if @textEditor?
+            @textEditor.selectAll()
+            @textEditor.delete()
             @gotTextEditor(@textEditor, params)
         else
             atom.workspace.getActivePane().splitDown()
-            self = this
-            wrapper = (editor) ->
-                self.gotTextEditor(editor, params)
             promise = atom.workspace.open()
-            promise.then(wrapper, @errOpeningTextEditor)
+            promise.then(
+                ( (editor) => @gotTextEditor(editor, params) ),
+                => @errOpeningTextEditor() )
         # options =
         #   cwd: atom.project.getPaths()[0]
         # spawn exec, params, options

--- a/lib/phpunit.coffee
+++ b/lib/phpunit.coffee
@@ -140,7 +140,7 @@ module.exports =
 
     execPHPUnit: (params)->
         options =
-          cwd: atom.project.getPaths()[0]
+            cwd: atom.project.getPaths()[0]
         spawn = require('child_process').spawn
         exec = atom.config.get "phpunit.execPath"
         useTextEditor = atom.config.get "phpunit.displayInTextBuffer"
@@ -177,8 +177,15 @@ module.exports =
 
     killProcess: ->
         if @phpunit.pid
-          @phpUnitView.append 'Killing current PHPUnit execution...<br>'
-          @phpunit.kill 'SIGHUP'
+            if useTextEditor
+                if @textEditor?
+                    @textEditor.insertText('Killing current PHPUnit execution...')
+            else
+                @phpUnitView.append 'Killing current PHPUnit execution...<br>'
+                @phpunit.kill 'SIGHUP'
 
     hideView: ->
         @phpUnitView.close()
+
+    getTextEditor: ->
+        return @textEditor

--- a/menus/phpunit.cson
+++ b/menus/phpunit.cson
@@ -8,6 +8,7 @@
                 { 'label': 'Run All Tests', 'command': 'phpunit:alltests' },
                 { 'label': 'Run Current Test', 'command': 'phpunit:current' }
                 { 'label': 'Run Open Tests', 'command': 'phpunit:workspace' }
+                { 'label': 'Hide', 'command': 'phpunit:hide'}
             ]
         ]
     }


### PR DESCRIPTION
This is an example of phpunit output directed to a text buffer to support a vim-mode user's workflow. When running phpunit for the first time, the current pane is split down and output is placed in a new text buffer. That text buffer is reused for subsequent phpunit runs unless it's closed.

Currently, the original output window is commented out. If this looks like a useful addition, I'll clean up the code and make output to the window or to a text buffer configurable.

Other to-dos:
* auto-save the text buffer output to a configurable filename so the buffer can be closed without confirmation.
* add support for opening the file and jumping to the line of the failing test as is supported in the original output window 
* set focus to buffer when executing tests