### PR TITLE
Add fix for shell path issues

### DIFF
--- a/lib/phpunit.coffee
+++ b/lib/phpunit.coffee
@@ -141,9 +141,16 @@ module.exports =
     execPHPUnit: (params)->
         options =
             cwd: atom.project.getPaths()[0]
-        spawn = require('child_process').spawn
+        childProcess = require('child_process')
         exec = atom.config.get "phpunit.execPath"
         useTextEditor = atom.config.get "phpunit.displayInTextBuffer"
+        process.env.PATH = String(
+            childProcess.execFileSync(\
+                process.env.SHELL,
+                ['-c', 'source $HOME/.bash_profile; echo $PATH']
+            )
+        ).trim()
+        spawn = childProcess.spawn
 
         @phpunit = spawn exec, params, options
 


### PR DESCRIPTION
I ran into an issue where running PHPUnit tests in atom would give an error stating that PHPUnit required PHP 5.6 or greater, but Mac's built in PHP (version 5.5 at /usr/bin/php) was being used instead of the version I installed with Homebrew.

This commit fixes that issue by first trying to grab the $PATH from the current user's .bash_profile which will then allow Homebrew's version of PHP to always be used instead of trying to use the built in PHP version.